### PR TITLE
Feature/media

### DIFF
--- a/constants/file.go
+++ b/constants/file.go
@@ -1,0 +1,3 @@
+package constants
+
+const CHUNK_SIZE uint = 5242880 // 5 Megabytes in bytes

--- a/docs/requests/loadfile.md
+++ b/docs/requests/loadfile.md
@@ -1,0 +1,52 @@
+# Transfer File Metadata
+
+## Description
+Send file metadata to the room.
+This request aims to advertise room peers to know file size and other information related for the further transfer.
+
+*Note: only the room owner can make this request.*
+
+## Request
+
+```json
+{
+	"code": "LFI",
+	"payload": {
+		"name": "<fileName", // should be between 3 and 254 characters
+		"size": <uint>
+	}
+}
+```
+
+## Return value
+
+```json
+{
+	"requestCode": "LFI",
+	"payload": null
+}
+```
+
+The file metadata and other informations is sent to all room peers, including you. See [this](../responses/loadfile.md).
+
+## Examples
+
+```json
+// Client request
+{
+	"code": "LFI",
+	"payload": {
+		"name": "Inception",
+		"size": 2641404887 //2.46 GB
+	}
+}
+// Server response
+{
+	"code": "LFI",
+	"payload": null
+}
+// File metadata processed by server
+{
+	…
+}
+```

--- a/docs/requests/loadfile.md
+++ b/docs/requests/loadfile.md
@@ -2,7 +2,7 @@
 
 ## Description
 Send file metadata to the room.
-This request aims to advertise room peers to know file size and other information related for the further transfer.
+This request aims to notify room peers about the file size and other information related for the further transfer.
 
 *Note: only the room owner can make this request.*
 

--- a/docs/requests/uploadchunk.md
+++ b/docs/requests/uploadchunk.md
@@ -1,0 +1,54 @@
+# Transfer File Chunk
+
+## Description
+Send file chunks to the room.
+This request aims to transfer a piece of file to other peers in the same room.
+
+The writer is responsible to send a chunk of the correct size (5MB). Only the last piece of chunk of the file can be of a lower size.
+
+*Note: only the room owner can make this request.*
+
+## Request
+
+```json
+{
+	"code": "UCH",
+	"payload": {
+		"chunkNumber": "<uint>",
+	  "chunkData": "<array of bytes>"
+  }
+}
+```
+
+## Return value
+
+```json
+{
+	"requestCode": "UCH",
+	"payload": null
+}
+```
+
+The file chunk is sent to all room peers, including you. See [this](../responses/uploadchunk.md).
+
+## Examples
+
+```json
+// Client request
+{
+	"code": "UCH",
+	"payload": {
+		"chunkNumber": "10",
+		"chunkData": "[<raw data>]"
+	}
+}
+// Server response
+{
+	"code": "UCH",
+	"payload": null
+}
+// File chunk returned by server
+{
+	…
+}
+```

--- a/docs/responses/loadfile.md
+++ b/docs/responses/loadfile.md
@@ -1,0 +1,25 @@
+# Transfer File Metadata
+
+## Description
+File metadata to be able to accept further incoming chunks of file.
+
+## Response
+	Name      string `json:"name"`      // Name of file
+	Size      uint64 `json:"size"`      // Size of file, in bytes
+	ChunkSize uint   `json:"chunkSize"` // Chunk size, in bytes
+	Chunks    uint16 `json:"chunks"`    // Number of chunks
+
+```json
+{
+	"code": "LFI",
+	"payload": {
+		"name": "<fileName>",
+		"size": "<fileSize>",
+		"chunkSize": "<chunkSize>",
+		"chunks": "<chunksNumber>"
+	}
+}
+```
+
+## Examples
+See full example in [file transfer](../requests/loadfile.md).

--- a/docs/responses/loadfile.md
+++ b/docs/responses/loadfile.md
@@ -4,10 +4,6 @@
 File metadata to be able to accept further incoming chunks of file.
 
 ## Response
-	Name      string `json:"name"`      // Name of file
-	Size      uint64 `json:"size"`      // Size of file, in bytes
-	ChunkSize uint   `json:"chunkSize"` // Chunk size, in bytes
-	Chunks    uint16 `json:"chunks"`    // Number of chunks
 
 ```json
 {

--- a/docs/responses/uploadchunk.md
+++ b/docs/responses/uploadchunk.md
@@ -1,0 +1,24 @@
+# Transfer File Chunk
+
+## Description
+Receiv file chunks to the room.
+This request aims to transfer a piece of file to other peers in the same room.
+
+The readers (i.e. other peers) is responsible to write the file accordingly to the file metadata transfered before (see [Transfer File Metadata](../responses/loadfile.md)) by moving the writing head.
+
+## Response
+
+The response is the same as the request by the writer (room owner).
+
+```json
+{
+	"code": "UCH",
+	"payload": {
+		"chunkNumber": "<uint>",
+	  "chunkData": "<array of bytes>"
+  }
+}
+```
+
+## Examples
+See full example in [Transfer File Chunk](../requests/uploadFile.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,18 +1,20 @@
 site_name: Dionysos server
 site_url: https://github.com/Brawdunoir/dionysos-server
 nav:
-  - Getting started: index.md
-  - Requests:
-      - requests/changeusername.md
-      - requests/newroom.md
-      - requests/joinroom.md
-      - requests/joinroomanswer.md
-      - requests/quitroom.md
-      - requests/kickpeer.md
-      - requests/changeowner.md
-      - requests/message.md
-  - Responses:
-      - responses/connection.md
-      - responses/newpeers.md
-      - responses/joinroompending.md
+    - Getting started: index.md
+    - Requests:
+          - requests/changeusername.md
+          - requests/newroom.md
+          - requests/joinroom.md
+          - requests/joinroomanswer.md
+          - requests/quitroom.md
+          - requests/kickpeer.md
+          - requests/changeowner.md
+          - requests/message.md
+          - requests/loadfile.md
+    - Responses:
+          - responses/connection.md
+          - responses/newpeers.md
+          - responses/joinroompending.md
+          - responses/loadfile.md
 theme: readthedocs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,9 +12,11 @@ nav:
           - requests/changeowner.md
           - requests/message.md
           - requests/loadfile.md
+          - requests/uploadchunk.md
     - Responses:
           - responses/connection.md
           - responses/newpeers.md
           - responses/joinroompending.md
           - responses/loadfile.md
+          - responses/uploadchunk.md
 theme: readthedocs

--- a/objects/filemetadata.go
+++ b/objects/filemetadata.go
@@ -1,0 +1,9 @@
+package objects
+
+// File metadata gathers metadata about a file
+type FileMetadata struct {
+	Name      string `json:"name"`      // Name of file
+	Size      uint64 `json:"size"`      // Size of file, in bytes
+	ChunkSize uint   `json:"chunkSize"` // Chunk size, in bytes
+	Chunks    uint16 `json:"chunks"`    // Number of chunks
+}

--- a/objects/room.go
+++ b/objects/room.go
@@ -13,12 +13,13 @@ type PeersType []*User
 
 // room represents data about a room for peers.
 type Room struct {
-	ID        string     `json:"id"`
-	Name      string     `json:"name"`
-	OwnerID   string     `json:"ownerid"`
-	Peers     PeersType  `json:"peers"`
-	IsPrivate bool       `json:"isPrivate"`
-	mu        sync.Mutex `json:"-"`
+	ID           string       `json:"id"`
+	Name         string       `json:"name"`
+	OwnerID      string       `json:"ownerid"`
+	Peers        PeersType    `json:"peers"`
+	IsPrivate    bool         `json:"isPrivate"`
+	FileMetadata FileMetadata `json:"fileMetadata"`
+	mu           sync.Mutex   `json:"-"`
 }
 
 func (r *Room) String() string {
@@ -95,6 +96,12 @@ func (r *Room) SendJSONToPeers(json interface{}, logger *zap.SugaredLogger) {
 		peer.SendJSON(json, logger)
 		logger.Debugw("peer has been notified of a message", "peer", peer.ID, "peername", peer.Name, "room", r.ID, "roomname", r.Name, "message", json)
 	}
+}
+
+func (r *Room) setFileMetadata(fileMetadata FileMetadata) {
+	r.mu.Lock()
+	r.FileMetadata = fileMetadata
+	r.mu.Unlock()
 }
 
 // Generate a room ID based on a roomname and an ownerPublicAddr

--- a/requests/helpers.go
+++ b/requests/helpers.go
@@ -1,6 +1,7 @@
 package requests
 
 import (
+	"encoding/binary"
 	"errors"
 
 	"github.com/Brawdunoir/dionysos-server/constants"
@@ -100,6 +101,26 @@ func notifyPeers(rooms *obj.Rooms, room *obj.Room, logger *zap.SugaredLogger) er
 	room.SendJSONToPeers(mes, logger)
 
 	logger.Infow("notify peers", "room", room.ID, "roomname", room.Name)
+
+	return nil
+}
+
+// Validates a chunk metadata.
+// A regular chunk should be the exact same size as the constant CHUNK_SIZE.
+// The last chunk of the file should have a size inferior then the constant CHUNK_SIZE.
+func validateChunkData(metadata obj.FileMetadata, request UploadChunkRequest) error {
+	err := errors.New("wrong chunkdata size")
+	chunkSize := binary.Size(request.ChunkData)
+
+	if metadata.Chunks == request.ChunkNumber {
+		if chunkSize > int(metadata.ChunkSize) {
+			return err
+		}
+	} else {
+		if chunkSize != int(metadata.ChunkSize) {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/requests/irequest.go
+++ b/requests/irequest.go
@@ -18,7 +18,7 @@ const (
 	JOIN_ROOM = "JRO"
 	// Follow a JOIN_ROOM request. Grant or deny user access to the room, return nothing.
 	JOIN_ROOM_ANSWER = "JRA"
-	// Forward the message to all peers within the room. The messages are not keeped in the rooms.
+	// Forward the message to all peers within the room. The messages are not kept in the rooms.
 	NEW_MESSAGE = "NME"
 	// Change the username
 	CHANGE_USERNAME = "CHU"

--- a/requests/irequest.go
+++ b/requests/irequest.go
@@ -30,6 +30,8 @@ const (
 	KICK_PEER = "KPE"
 	// Ask to load a file in the room
 	LOAD_FILE = "LFI"
+	// Upload file chunk. It is only forwarded to peers and not keeped in the server
+	UPLOAD_CHUNK = "UCH"
 )
 
 type IRequest interface {

--- a/requests/irequest.go
+++ b/requests/irequest.go
@@ -28,6 +28,8 @@ const (
 	QUIT_ROOM = "QRO"
 	// Ask to kick a peer
 	KICK_PEER = "KPE"
+	// Ask to load a file in the room
+	LOAD_FILE = "LFI"
 )
 
 type IRequest interface {

--- a/requests/loadfile.go
+++ b/requests/loadfile.go
@@ -14,7 +14,6 @@ import (
 type LoadFileRequest struct {
 	Name string `json:"name" validate:"min=3,max=254"` // Name of file
 	Size uint64 `json:"size" validate:"min=1"`         // Size of file, in bytes
-
 }
 
 // Handle a file metadata upload. Happens just before the room's owner starts to upload file

--- a/requests/loadfile.go
+++ b/requests/loadfile.go
@@ -1,0 +1,57 @@
+package requests
+
+import (
+	"encoding/json"
+	"math"
+
+	"github.com/Brawdunoir/dionysos-server/constants"
+	obj "github.com/Brawdunoir/dionysos-server/objects"
+	res "github.com/Brawdunoir/dionysos-server/responses"
+	"go.uber.org/zap"
+)
+
+// LoadFileRequest sets fileMetadata for the room and send file metadata to other peers
+type LoadFileRequest struct {
+	Name string `json:"name" validate:"min=3,max=254"` // Name of file
+	Size uint64 `json:"size" validate:"min=1"`         // Size of file, in bytes
+
+}
+
+// Handle a file metadata upload. Happens just before the room's owner starts to upload file
+func (r LoadFileRequest) Handle(client *obj.User, users *obj.Users, rooms *obj.Rooms, logger *zap.SugaredLogger) (response res.Response) {
+	// Fetch room info
+	room, err := rooms.Room(client.RoomID, logger)
+	if err != nil {
+		response = res.NewErrorResponse(err.Error(), logger)
+		return
+	}
+
+	// Assert user from this request is the legal owner of the room
+	if room.OwnerID != client.ID {
+		response = res.NewErrorResponse(constants.ERR_NO_PERM, logger)
+		return
+	}
+
+	// Set the fileMetadata and forward metadata to other peers
+	// Chunks is basically the number of chunks that the file is composed from
+	// (i.e. file total size divided by a single chunk size)
+	chunks := uint16(math.Ceil(float64(r.Size) / float64(constants.CHUNK_SIZE)))
+	room.FileMetadata = obj.FileMetadata{Name: r.Name, Size: r.Size, ChunkSize: constants.CHUNK_SIZE, Chunks: chunks}
+
+	mes := res.NewResponse(res.LoadFileResponse(room.FileMetadata), logger)
+	room.SendJSONToPeers(mes, logger)
+
+	logger.Infow("load file request success", "fileName", r.Name, "fileSize", r.Size, "room", room.ID, "roomname", room.Name)
+
+	response = res.NewResponse(res.SuccessResponse{RequestCode: res.CodeType(r.Code())}, logger)
+	return
+}
+
+func (r LoadFileRequest) Code() CodeType {
+	return LOAD_FILE
+}
+
+func createLoadFileRequest(payload json.RawMessage) (r LoadFileRequest, err error) {
+	err = json.Unmarshal(payload, &r)
+	return
+}

--- a/requests/request.go
+++ b/requests/request.go
@@ -60,6 +60,8 @@ func (r Request) Handle(client *obj.User, users *obj.Users, rooms *obj.Rooms, lo
 		req, err = createChangeOwnerRequest(r.Payload)
 	case LOAD_FILE:
 		req, err = createLoadFileRequest(r.Payload)
+	case UPLOAD_CHUNK:
+		req, err = createUploadChunkRequest(r.Payload)
 	default:
 		response = res.NewErrorResponse(fmt.Sprint(constants.ERR_UNKNOW_CODE, ": ", r.Code), logger)
 		return

--- a/requests/request.go
+++ b/requests/request.go
@@ -58,6 +58,8 @@ func (r Request) Handle(client *obj.User, users *obj.Users, rooms *obj.Rooms, lo
 		req, err = createKickPeerRequest(r.Payload)
 	case CHANGE_OWNER:
 		req, err = createChangeOwnerRequest(r.Payload)
+	case LOAD_FILE:
+		req, err = createLoadFileRequest(r.Payload)
 	default:
 		response = res.NewErrorResponse(fmt.Sprint(constants.ERR_UNKNOW_CODE, ": ", r.Code), logger)
 		return

--- a/requests/uploadchunk.go
+++ b/requests/uploadchunk.go
@@ -1,0 +1,59 @@
+package requests
+
+import (
+	"encoding/json"
+
+	"github.com/Brawdunoir/dionysos-server/constants"
+	obj "github.com/Brawdunoir/dionysos-server/objects"
+	res "github.com/Brawdunoir/dionysos-server/responses"
+	"go.uber.org/zap"
+)
+
+// UploadChunkRequest uploads a piece of file (chunk) to the server so it can forward it to other peers
+type UploadChunkRequest struct {
+	ChunkNumber uint16 `json:"chunkNumber" validate:"nonzero"`
+	ChunkData   []byte `json:"chunkData"` // Chunk data is validated during request in the handler
+}
+
+// Handle a chunk upload by forwarding it to the other peers in the room.
+// Validates that the size of chunk data is exactly the same as the constant CHUNK_SIZE.
+// Except for the last chunk, which can have a lower size.
+func (r UploadChunkRequest) Handle(client *obj.User, users *obj.Users, rooms *obj.Rooms, logger *zap.SugaredLogger) (response res.Response) {
+	// Fetch room info
+	room, err := rooms.Room(client.RoomID, logger)
+	if err != nil {
+		response = res.NewErrorResponse(err.Error(), logger)
+		return
+	}
+
+	// Assert user from this request is the legal owner of the room
+	if room.OwnerID != client.ID {
+		response = res.NewErrorResponse(constants.ERR_NO_PERM, logger)
+		return
+	}
+
+	// Validates chunk data length
+	err = validateChunkData(room.FileMetadata, r)
+	if err != nil {
+		response = res.NewErrorResponse(err.Error(), logger)
+		return
+	}
+
+	// Send the chunk to all peers in the room
+	mes := res.NewResponse(res.UploadChunkResponse(r), logger)
+	room.SendJSONToPeers(mes, logger)
+
+	logger.Infow("upload chunk request success", "chunkNumber", r.ChunkNumber, "fileName", room.FileMetadata.Name, "chunkSize", room.FileMetadata.ChunkSize, "fileSize", room.FileMetadata.Size, "room", room.ID, "roomname", room.Name)
+
+	response = res.NewResponse(res.SuccessResponse{RequestCode: res.CodeType(r.Code())}, logger)
+	return
+}
+
+func (r UploadChunkRequest) Code() CodeType {
+	return UPLOAD_CHUNK
+}
+
+func createUploadChunkRequest(payload json.RawMessage) (r UploadChunkRequest, err error) {
+	err = json.Unmarshal(payload, &r)
+	return
+}

--- a/responses/iresponse.go
+++ b/responses/iresponse.go
@@ -22,6 +22,8 @@ const (
 	NEW_MESSAGE = "NME"
 	// Signal that the username has been changed internally
 	CHANGE_USERNAME = "CHU"
+	// Signal that a new file has been loaded (and that fragments will be sent)
+	LOAD_FILE = "LFI"
 )
 
 type IResponse interface {

--- a/responses/iresponse.go
+++ b/responses/iresponse.go
@@ -24,6 +24,8 @@ const (
 	CHANGE_USERNAME = "CHU"
 	// Signal that a new file has been loaded (and that fragments will be sent)
 	LOAD_FILE = "LFI"
+	// Upload file chunk. It is only forwarded to peers and not keeped in the server
+	UPLOAD_CHUNK = "UCH"
 )
 
 type IResponse interface {

--- a/responses/loadfile.go
+++ b/responses/loadfile.go
@@ -1,0 +1,19 @@
+package responses
+
+import (
+	"encoding/json"
+
+	"github.com/Brawdunoir/dionysos-server/objects"
+)
+
+// LoadFileResponse correspond to a successful LoadFileRequest.
+// It sends file metadata to peers in the room.
+type LoadFileResponse objects.FileMetadata
+
+func (r LoadFileResponse) Code() CodeType {
+	return LOAD_FILE
+}
+
+func (r LoadFileResponse) Marshal() ([]byte, error) {
+	return json.Marshal(r)
+}

--- a/responses/uploadchunk.go
+++ b/responses/uploadchunk.go
@@ -1,0 +1,17 @@
+package responses
+
+import "encoding/json"
+
+// UploadChunkResponse is the counterpart of UploadChunkRequest and is forwarded to peers in the room
+type UploadChunkResponse struct {
+	ChunkNumber uint16 `json:"chunkNumber" validate:"nonzero"`
+	ChunkData   []byte `json:"chunkData"` // Chunk data is validated during request in the handler
+}
+
+func (r UploadChunkResponse) Code() CodeType {
+	return UPLOAD_CHUNK
+}
+
+func (r UploadChunkResponse) Marshal() ([]byte, error) {
+	return json.Marshal(r)
+}


### PR DESCRIPTION
Add media sharing.

This can be done via two requests :

1) LFI (Load File) which send file metadata.
2) UCH (Upload Chunk) which send file chunk.

The second request (UCH) can be done N time depending on the file length. The server acts as a broadcaster. 